### PR TITLE
Events Reference - Review User parameters

### DIFF
--- a/developers/tracking/events-reference.md
+++ b/developers/tracking/events-reference.md
@@ -703,6 +703,10 @@ Example :
 }
 ```
 
+> :information_source: we only support hex (base16) encoding<br>
+> *(i.e.: **hashed** values are carried by strings with [0-9a-f] characters)*<br>
+> Other encodings are not supported yet
+
 No need to send both **plain** and **hashed** values :
 * if you send **plain** value, the **hashed** values aren't necessary<br>
 *We can generate **hashed** values on server side using **plain** value*


### PR DESCRIPTION
## Context

We want to clarify the rules applied on user properties that anyone (especially clients) should be aware of.

## Changes

* Update [**User** section](https://github.com/TagCommander/Platform-Documentation/blob/evol/adub/user-emails/developers/tracking/events-reference.md#user) of Events Reference
  * specify `email_md5`, `email_sha256` in the list of user properties
  * specify additional fields about user identity and address (`firstname`, `gender`, `city`, `country`, ...)
  * add some descriptions
* Fix *purchase* automatically added fields by removing `consent_categories` (not relevant at this place)