### PR TITLE
Generate Events Reference from schema

### DIFF
--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -9,11 +9,11 @@ This event signifies a user has submitted their payment information
 | ---- | ---- | -------- | ------- | ----------- |
 | `payment_method` | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
 | `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -48,10 +48,10 @@ This event signifies a user has submitted their shipping information.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -86,7 +86,7 @@ This event signifies that an item was added to a cart for purchase.
 | `value` | `number` | Yes | 8.00 | The monetary value of the event |
 | `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -118,9 +118,9 @@ The event signifies that an item was added to a wishlist. Use this event to iden
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -156,7 +156,7 @@ This event signifies that a user has begun a checkout.
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -190,8 +190,8 @@ Log this event when a lead has been generated to understand the efficacy of your
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -215,17 +215,17 @@ Send this event to signify that a user has logged in.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 | `method` | `string` | No | LinkedIn | The method used to login. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
 ```javascript
 cact('trigger', login, {
+  "method": "LinkedIn",
   "user": {
     "id": "84545"
-  },
-  "method": "LinkedIn"
+  }
 })
 ```
 
@@ -240,7 +240,7 @@ The `page_view` call lets you record whenever a user sees a page of your website
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `type` | `string` | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -273,7 +273,7 @@ Fire this event when one or more items are purchased by a user.
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -319,7 +319,7 @@ Fire this event when a purchase was refund.
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | `items` is required for partial refunds, but it can be omitted for full refunds. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -356,9 +356,9 @@ This event signifies that an item was removed from a cart.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -390,7 +390,7 @@ Use this event to contextualize search operations. This event can help you ident
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `search_term` | `string` | Yes | t-shirt | The term that was searched for. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -415,7 +415,7 @@ This event signifies that a user has selected some content of a certain type. Th
 | ---- | ---- | -------- | ------- | ----------- |
 | `content_type` | `string` | No | product | The type of selected content. |
 | `item_id` | `string` | No | I_12345 | An identifier for the item that was selected. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -440,7 +440,7 @@ This event signifies an item was selected from a list.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -469,17 +469,17 @@ This event indicates that a user has signed up for an account.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 | `method` | `string` | No | email | The method used for sign up. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
 ```javascript
 cact('trigger', sign_up, {
+  "method": "email",
   "user": {
     "id": "84545"
-  },
-  "method": "email"
+  }
 })
 ```
 
@@ -494,9 +494,9 @@ This event signifies that a user viewed their cart.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -528,9 +528,9 @@ This event signifies that some content was shown to the user. Use this event to 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -562,7 +562,7 @@ Log this event when the user has been presented with a list of items of a certai
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -1,16 +1,16 @@
 
-## add_payment_info <a href="#add_payment_info" id="add_payment_info"></a>
+## add\_payment\_info <a href="#add_payment_info" id="add_payment_info"></a>
 
 This event signifies a user has submitted their payment information
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| payment_method | string | Yes | card | The chosen method of payment (see list of possible values below) |
-| value | string | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| revenue | string | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| coupon | string | No | CHRISTMAS | Coupon code used for a purchase. |
-| items | <a href="#item>">Array&lt;Object&lt;Item&gt;&gt;</a> | No | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+| payment_method | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
+| value | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| items | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -35,16 +35,16 @@ cact('trigger', add_payment_info, {
 
 
 
-## add_shipping_info <a href="#add_shipping_info" id="add_shipping_info"></a>
+## add\_shipping\_info <a href="#add_shipping_info" id="add_shipping_info"></a>
 
 This event signifies a user has submitted their shipping information.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | string | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| coupon | string | No | CHRISTMAS | Coupon code used for a purchase. |
-| items | <a href="#item>">Array&lt;Object&lt;Item&gt;&gt;</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+| value | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -73,8 +73,8 @@ Send this event to signify that a user has logged in.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
-| method | string | No | LinkedIn | The method used to login. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| method | `string` | No | LinkedIn | The method used to login. |
 
 **Parameters (required and recommended)**
 
@@ -89,14 +89,14 @@ cact('trigger', login, {
 
 
 
-## page_view <a href="#page_view" id="page_view"></a>
+## page\_view <a href="#page_view" id="page_view"></a>
 
 The `page_view` call lets you record whenever a user sees a page of your website, along with any optional properties about the page.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| type | string | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
-| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+| type | `string` | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -117,16 +117,16 @@ Fire this event when one or more items are purchased by a user.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| payment_method | string | Yes | card | Payment method type (see list of possible values below) |
-| status | string | Yes | in_progress | Status of the conversion (see list of  below). Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
-| value | string | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| revenue | string | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| shipping_amount | string | No | 3.33 | Shipping cost associated with a transaction. |
-| tax_amount | string | No | 3.33 | Tax cost associated with a transaction. |
-| coupon | string | No | CHRISTMAS | Coupon code used for a purchase. |
-| type | string | Yes | offline | Type of conversion (online, offline, call etc.) |
-| items | <a href="#item>">Array&lt;Object&lt;Item&gt;&gt;</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+| payment_method | `string` | Yes | card | Payment method type (see list of possible values below) |
+| status | `string` | Yes | in_progress | Status of the conversion (see list of  below). Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
+| value | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| revenue | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| shipping_amount | `string` | No | 3.33 | Shipping cost associated with a transaction. |
+| tax_amount | `string` | No | 3.33 | Tax cost associated with a transaction. |
+| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| type | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -140,6 +140,42 @@ cact('trigger', purchase, {
   "tax_amount": 3.33,
   "coupon": "CHRISTMAS",
   "type": "offline",
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## add\_payment\_info <a href="#add_payment_info" id="add_payment_info"></a>
+
+This event signifies a user has submitted their payment information
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| payment_method | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
+| value | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| items | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', add_payment_info, {
+  "payment_method": "card",
+  "value": 22.53,
+  "revenue": 16,
+  "coupon": "CHRISTMAS",
   "items": [
     {
       "product": {

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -67,6 +67,122 @@ cact('trigger', add_shipping_info, {
 
 
 
+## add\_to\_cart <a href="#add_to_cart" id="add_to_cart"></a>
+
+This event signifies that an item was added to a cart for purchase.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | `string` | Yes | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', add_to_cart, {
+  "value": 8,
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## add\_to\_wishlist <a href="#add_to_wishlist" id="add_to_wishlist"></a>
+
+The event signifies that an item was added to a wishlist. Use this event to identify popular gift items in your app.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', add_to_wishlist, {
+  "value": 8,
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## begin\_checkout <a href="#begin_checkout" id="begin_checkout"></a>
+
+This event signifies that a user has begun a checkout.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', begin_checkout, {
+  "value": 22.53,
+  "revenue": 16,
+  "coupon": "CHRISTMAS",
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## generate\_lead <a href="#generate_lead" id="generate_lead"></a>
+
+Log this event when a lead has been generated to understand the efficacy of your re-engagement campaigns.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', generate_lead, {
+  "value": 8,
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
 ## login <a href="#login" id="login"></a>
 
 Send this event to signify that a user has logged in.
@@ -118,7 +234,7 @@ Fire this event when one or more items are purchased by a user.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | payment_method | `string` | Yes | card | Payment method type (see list of possible values below) |
-| status | `string` | Yes | in_progress | Status of the conversion (see list of  below). Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
+| status | `string` | Yes | in_progress | Status of the conversion (see list of  below). <br>Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
 | value | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | revenue | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | shipping_amount | `string` | No | 3.33 | Shipping cost associated with a transaction. |
@@ -140,6 +256,260 @@ cact('trigger', purchase, {
   "tax_amount": 3.33,
   "coupon": "CHRISTMAS",
   "type": "offline",
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## refund <a href="#refund" id="refund"></a>
+
+Fire this event when a purchase was refund.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| revenue | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| shipping_amount | `string` | No | 3.33 | Shipping cost associated with a transaction. |
+| tax_amount | `string` | No | 3.33 | Tax cost associated with a transaction. |
+| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| type | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
+| items | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | `items` is required for partial refunds, but it can be omitted for full refunds. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', refund, {
+  "value": 22.53,
+  "revenue": 16,
+  "shipping_amount": 3.33,
+  "tax_amount": 3.33,
+  "coupon": "CHRISTMAS",
+  "type": "offline",
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## remove\_from\_cart <a href="#remove_from_cart" id="remove_from_cart"></a>
+
+This event signifies that an item was removed from a cart.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', remove_from_cart, {
+  "value": 8,
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## search <a href="#search" id="search"></a>
+
+Use this event to contextualize search operations. This event can help you identify the most popular content in your app.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| search_term | `string` | Yes | t-shirt | The term that was searched for. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', search, {
+  "search_term": "t-shirt",
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## select\_content <a href="#select_content" id="select_content"></a>
+
+This event signifies that a user has selected some content of a certain type. This event can help you identify popular content and categories of content in your app or click on internal promotion.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| content_type | `string` | No | product | The type of selected content. |
+| item_id | `string` | No | I_12345 | An identifier for the item that was selected. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', select_content, {
+  "content_type": "product",
+  "item_id": "I_12345",
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## select\_item <a href="#select_item" id="select_item"></a>
+
+This event signifies an item was selected from a list.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', select_item, {
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## sign\_up <a href="#sign_up" id="sign_up"></a>
+
+This event indicates that a user has signed up for an account.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| method | `string` | No | email | The method used for sign up. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', sign_up, {
+  "user": {
+    "id": "84545"
+  },
+  "method": "email"
+})
+```
+
+
+
+## view\_cart <a href="#view_cart" id="view_cart"></a>
+
+This event signifies that a user viewed their cart.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', view_cart, {
+  "value": 8,
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## view\_item <a href="#view_item" id="view_item"></a>
+
+This event signifies that some content was shown to the user. Use this event to manage the most popular items viewed.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', view_item, {
+  "revenue": 16,
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## view\_item\_list <a href="#view_item_list" id="view_item_list"></a>
+
+Log this event when the user has been presented with a list of items of a certain category.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', view_item_list, {
   "items": [
     {
       "product": {

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -1,0 +1,156 @@
+
+## add_payment_info <a href="#add_payment_info" id="add_payment_info"></a>
+
+This event signifies a user has submitted their payment information
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| payment_method | string | Yes | card | The chosen method of payment (see list of possible values below) |
+| value | string | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| revenue | string | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| coupon | string | No | CHRISTMAS | Coupon code used for a purchase. |
+| items | <a href="#item>">Array&lt;Object&lt;Item&gt;&gt;</a> | No | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', add_payment_info, {
+  "payment_method": "card",
+  "value": 22.53,
+  "revenue": 16,
+  "coupon": "CHRISTMAS",
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## add_shipping_info <a href="#add_shipping_info" id="add_shipping_info"></a>
+
+This event signifies a user has submitted their shipping information.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| value | string | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| coupon | string | No | CHRISTMAS | Coupon code used for a purchase. |
+| items | <a href="#item>">Array&lt;Object&lt;Item&gt;&gt;</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', add_shipping_info, {
+  "value": 22.53,
+  "coupon": "CHRISTMAS",
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## login <a href="#login" id="login"></a>
+
+Send this event to signify that a user has logged in.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+| method | string | No | LinkedIn | The method used to login. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', login, {
+  "user": {
+    "id": "84545"
+  },
+  "method": "LinkedIn"
+})
+```
+
+
+
+## page_view <a href="#page_view" id="page_view"></a>
+
+The `page_view` call lets you record whenever a user sees a page of your website, along with any optional properties about the page.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| type | string | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
+| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', page_view, {
+  "type": "product_list",
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+## purchase <a href="#purchase" id="purchase"></a>
+
+Fire this event when one or more items are purchased by a user.
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| payment_method | string | Yes | card | Payment method type (see list of possible values below) |
+| status | string | Yes | in_progress | Status of the conversion (see list of  below). Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
+| value | string | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| revenue | string | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| shipping_amount | string | No | 3.33 | Shipping cost associated with a transaction. |
+| tax_amount | string | No | 3.33 | Tax cost associated with a transaction. |
+| coupon | string | No | CHRISTMAS | Coupon code used for a purchase. |
+| type | string | Yes | offline | Type of conversion (online, offline, call etc.) |
+| items | <a href="#item>">Array&lt;Object&lt;Item&gt;&gt;</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| user | <a href="#user">Object&lt;User&gt;</a> | Yes | {"id":"84545"} | The items for the event. |
+
+**Parameters (required and recommended)**
+
+```javascript
+cact('trigger', purchase, {
+  "payment_method": "card",
+  "status": "in_progress",
+  "value": 22.53,
+  "revenue": 16,
+  "shipping_amount": 3.33,
+  "tax_amount": 3.33,
+  "coupon": "CHRISTMAS",
+  "type": "offline",
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -3,21 +3,25 @@
 
 This event signifies a user has submitted their payment information
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `payment_method` | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
-| `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
+| `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', add_payment_info, {
   "payment_method": "card",
   "value": 22.53,
+  "currency": "EUR",
   "revenue": 16,
   "coupon": "CHRISTMAS",
   "items": [
@@ -39,18 +43,22 @@ cact('trigger', add_payment_info, {
 
 This event signifies a user has submitted their shipping information.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', add_shipping_info, {
   "value": 22.53,
+  "currency": "EUR",
   "coupon": "CHRISTMAS",
   "items": [
     {
@@ -71,17 +79,21 @@ cact('trigger', add_shipping_info, {
 
 This event signifies that an item was added to a cart for purchase.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | Yes | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `value` | `number` | Yes | 8.00 | The monetary value of the event |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', add_to_cart, {
   "value": 8,
+  "currency": "EUR",
   "items": [
     {
       "product": {
@@ -101,17 +113,21 @@ cact('trigger', add_to_cart, {
 
 The event signifies that an item was added to a wishlist. Use this event to identify popular gift items in your app.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', add_to_wishlist, {
   "value": 8,
+  "currency": "EUR",
   "items": [
     {
       "product": {
@@ -131,19 +147,23 @@ cact('trigger', add_to_wishlist, {
 
 This event signifies that a user has begun a checkout.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
+| `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', begin_checkout, {
   "value": 22.53,
+  "currency": "EUR",
   "revenue": 16,
   "coupon": "CHRISTMAS",
   "items": [
@@ -165,16 +185,20 @@ cact('trigger', begin_checkout, {
 
 Log this event when a lead has been generated to understand the efficacy of your re-engagement campaigns.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', generate_lead, {
   "value": 8,
+  "currency": "EUR",
   "user": {
     "id": "84545"
   }
@@ -187,12 +211,14 @@ cact('trigger', generate_lead, {
 
 Send this event to signify that a user has logged in.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 | `method` | `string` | No | LinkedIn | The method used to login. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', login, {
@@ -209,12 +235,14 @@ cact('trigger', login, {
 
 The `page_view` call lets you record whenever a user sees a page of your website, along with any optional properties about the page.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `type` | `string` | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', page_view, {
@@ -231,29 +259,33 @@ cact('trigger', page_view, {
 
 Fire this event when one or more items are purchased by a user.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `payment_method` | `string` | Yes | card | Payment method type (see list of possible values below) |
 | `status` | `string` | Yes | in_progress | Status of the conversion (see list of  below). <br>Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
-| `value` | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `revenue` | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| `shipping_amount` | `string` | No | 3.33 | Shipping cost associated with a transaction. |
-| `tax_amount` | `string` | No | 3.33 | Tax cost associated with a transaction. |
+| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
+| `revenue` | `number` | Yes | 16.00 | Revenue (shipping price and taxes **excluded**) after discount. |
+| `shipping_amount` | `number` | No | 3.33 | Shipping cost associated with a transaction. |
+| `tax_amount` | `number` | No | 3.20 | Tax cost associated with a transaction. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', purchase, {
   "payment_method": "card",
   "status": "in_progress",
   "value": 22.53,
+  "currency": "EUR",
   "revenue": 16,
   "shipping_amount": 3.33,
-  "tax_amount": 3.33,
+  "tax_amount": 3.2,
   "coupon": "CHRISTMAS",
   "type": "offline",
   "items": [
@@ -275,25 +307,29 @@ cact('trigger', purchase, {
 
 Fire this event when a purchase was refund.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `revenue` | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| `shipping_amount` | `string` | No | 3.33 | Shipping cost associated with a transaction. |
-| `tax_amount` | `string` | No | 3.33 | Tax cost associated with a transaction. |
+| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
+| `revenue` | `number` | Yes | 16.00 | Revenue (shipping price and taxes **excluded**) after discount. |
+| `shipping_amount` | `number` | No | 3.33 | Shipping cost associated with a transaction. |
+| `tax_amount` | `number` | No | 3.20 | Tax cost associated with a transaction. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | `items` is required for partial refunds, but it can be omitted for full refunds. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', refund, {
   "value": 22.53,
+  "currency": "EUR",
   "revenue": 16,
   "shipping_amount": 3.33,
-  "tax_amount": 3.33,
+  "tax_amount": 3.2,
   "coupon": "CHRISTMAS",
   "type": "offline",
   "items": [
@@ -315,17 +351,21 @@ cact('trigger', refund, {
 
 This event signifies that an item was removed from a cart.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', remove_from_cart, {
   "value": 8,
+  "currency": "EUR",
   "items": [
     {
       "product": {
@@ -345,12 +385,14 @@ cact('trigger', remove_from_cart, {
 
 Use this event to contextualize search operations. This event can help you identify the most popular content in your app.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `search_term` | `string` | Yes | t-shirt | The term that was searched for. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', search, {
@@ -367,13 +409,15 @@ cact('trigger', search, {
 
 This event signifies that a user has selected some content of a certain type. This event can help you identify popular content and categories of content in your app or click on internal promotion.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `content_type` | `string` | No | product | The type of selected content. |
 | `item_id` | `string` | No | I_12345 | An identifier for the item that was selected. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', select_content, {
@@ -391,12 +435,14 @@ cact('trigger', select_content, {
 
 This event signifies an item was selected from a list.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', select_item, {
@@ -419,12 +465,14 @@ cact('trigger', select_item, {
 
 This event indicates that a user has signed up for an account.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 | `method` | `string` | No | email | The method used for sign up. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', sign_up, {
@@ -441,17 +489,21 @@ cact('trigger', sign_up, {
 
 This event signifies that a user viewed their cart.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', view_cart, {
   "value": 8,
+  "currency": "EUR",
   "items": [
     {
       "product": {
@@ -471,17 +523,21 @@ cact('trigger', view_cart, {
 
 This event signifies that some content was shown to the user. Use this event to manage the most popular items viewed.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply the revenue parameter, you must also supply the currency parameter so revenue metrics can be computed accurately. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', view_item, {
   "revenue": 16,
+  "currency": "EUR",
   "items": [
     {
       "product": {
@@ -501,51 +557,17 @@ cact('trigger', view_item, {
 
 Log this event when the user has been presented with a list of items of a certain category.
 
+**Parameters (required and recommended)**
+
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
-**Parameters (required and recommended)**
+**Example**
 
 ```javascript
 cact('trigger', view_item_list, {
-  "items": [
-    {
-      "product": {
-        "id": 1234
-      }
-    }
-  ],
-  "user": {
-    "id": "84545"
-  }
-})
-```
-
-
-
-## add\_payment\_info <a href="#add_payment_info" id="add_payment_info"></a>
-
-This event signifies a user has submitted their payment information
-
-| Name | Type | Required | Example | Description |
-| ---- | ---- | -------- | ------- | ----------- |
-| `payment_method` | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
-| `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
-
-**Parameters (required and recommended)**
-
-```javascript
-cact('trigger', add_payment_info, {
-  "payment_method": "card",
-  "value": 22.53,
-  "revenue": 16,
-  "coupon": "CHRISTMAS",
   "items": [
     {
       "product": {

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -5,12 +5,12 @@ This event signifies a user has submitted their payment information
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| payment_method | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
-| value | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| items | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `payment_method` | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
+| `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -41,10 +41,10 @@ This event signifies a user has submitted their shipping information.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -73,9 +73,9 @@ This event signifies that an item was added to a cart for purchase.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | Yes | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | Yes | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -103,9 +103,9 @@ The event signifies that an item was added to a wishlist. Use this event to iden
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -133,11 +133,11 @@ This event signifies that a user has begun a checkout.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -167,8 +167,8 @@ Log this event when a lead has been generated to understand the efficacy of your
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -189,8 +189,8 @@ Send this event to signify that a user has logged in.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
-| method | `string` | No | LinkedIn | The method used to login. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `method` | `string` | No | LinkedIn | The method used to login. |
 
 **Parameters (required and recommended)**
 
@@ -211,8 +211,8 @@ The `page_view` call lets you record whenever a user sees a page of your website
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| type | `string` | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `type` | `string` | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -233,16 +233,16 @@ Fire this event when one or more items are purchased by a user.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| payment_method | `string` | Yes | card | Payment method type (see list of possible values below) |
-| status | `string` | Yes | in_progress | Status of the conversion (see list of  below). <br>Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
-| value | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| revenue | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| shipping_amount | `string` | No | 3.33 | Shipping cost associated with a transaction. |
-| tax_amount | `string` | No | 3.33 | Tax cost associated with a transaction. |
-| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| type | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `payment_method` | `string` | Yes | card | Payment method type (see list of possible values below) |
+| `status` | `string` | Yes | in_progress | Status of the conversion (see list of  below). <br>Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
+| `value` | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `revenue` | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `shipping_amount` | `string` | No | 3.33 | Shipping cost associated with a transaction. |
+| `tax_amount` | `string` | No | 3.33 | Tax cost associated with a transaction. |
+| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -277,14 +277,14 @@ Fire this event when a purchase was refund.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| revenue | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| shipping_amount | `string` | No | 3.33 | Shipping cost associated with a transaction. |
-| tax_amount | `string` | No | 3.33 | Tax cost associated with a transaction. |
-| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| type | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
-| items | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | `items` is required for partial refunds, but it can be omitted for full refunds. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `revenue` | `string` | Yes | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `shipping_amount` | `string` | No | 3.33 | Shipping cost associated with a transaction. |
+| `tax_amount` | `string` | No | 3.33 | Tax cost associated with a transaction. |
+| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | `items` is required for partial refunds, but it can be omitted for full refunds. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -317,9 +317,9 @@ This event signifies that an item was removed from a cart.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -347,8 +347,8 @@ Use this event to contextualize search operations. This event can help you ident
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| search_term | `string` | Yes | t-shirt | The term that was searched for. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `search_term` | `string` | Yes | t-shirt | The term that was searched for. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -369,9 +369,9 @@ This event signifies that a user has selected some content of a certain type. Th
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| content_type | `string` | No | product | The type of selected content. |
-| item_id | `string` | No | I_12345 | An identifier for the item that was selected. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `content_type` | `string` | No | product | The type of selected content. |
+| `item_id` | `string` | No | I_12345 | An identifier for the item that was selected. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -393,8 +393,8 @@ This event signifies an item was selected from a list.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -421,8 +421,8 @@ This event indicates that a user has signed up for an account.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
-| method | `string` | No | email | The method used for sign up. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `method` | `string` | No | email | The method used for sign up. |
 
 **Parameters (required and recommended)**
 
@@ -443,9 +443,9 @@ This event signifies that a user viewed their cart.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| value | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -473,9 +473,9 @@ This event signifies that some content was shown to the user. Use this event to 
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -503,8 +503,8 @@ Log this event when the user has been presented with a list of items of a certai
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| items | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -531,12 +531,12 @@ This event signifies a user has submitted their payment information
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| payment_method | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
-| value | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| revenue | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| coupon | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| items | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
-| user | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `payment_method` | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
+| `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
 
 **Parameters (required and recommended)**
 

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -21,7 +21,7 @@ This event signifies a user has submitted their payment information
 **Example**
 
 ```javascript
-cact('trigger', add_payment_info, {
+cact('trigger', 'add_payment_info', {
   "payment_method": "card",
   "revenue": 16,
   "value": 22.53,
@@ -59,7 +59,7 @@ This event signifies a user has submitted their shipping information.
 **Example**
 
 ```javascript
-cact('trigger', add_shipping_info, {
+cact('trigger', 'add_shipping_info', {
   "value": 22.53,
   "currency": "EUR",
   "coupon": "CHRISTMAS",
@@ -94,7 +94,7 @@ This event signifies that an item was added to a cart for purchase.
 **Example**
 
 ```javascript
-cact('trigger', add_to_cart, {
+cact('trigger', 'add_to_cart', {
   "value": 8,
   "currency": "EUR",
   "items": [
@@ -128,7 +128,7 @@ The event signifies that an item was added to a wishlist. Use this event to iden
 **Example**
 
 ```javascript
-cact('trigger', add_to_wishlist, {
+cact('trigger', 'add_to_wishlist', {
   "value": 8,
   "currency": "EUR",
   "items": [
@@ -164,7 +164,7 @@ This event signifies that a user has begun a checkout.
 **Example**
 
 ```javascript
-cact('trigger', begin_checkout, {
+cact('trigger', 'begin_checkout', {
   "revenue": 16,
   "value": 22.53,
   "currency": "EUR",
@@ -199,7 +199,7 @@ Log this event when a lead has been generated to understand the efficacy of your
 **Example**
 
 ```javascript
-cact('trigger', generate_lead, {
+cact('trigger', 'generate_lead', {
   "value": 8,
   "currency": "EUR",
   "user": {
@@ -224,7 +224,7 @@ Send this event to signify that a user has logged in.
 **Example**
 
 ```javascript
-cact('trigger', login, {
+cact('trigger', 'login', {
   "method": "LinkedIn",
   "user": {
     "id": "84545"
@@ -248,7 +248,7 @@ The `page_view` call lets you record whenever a user sees a page of your website
 **Example**
 
 ```javascript
-cact('trigger', page_view, {
+cact('trigger', 'page_view', {
   "type": "product_list",
   "user": {
     "id": "84545"
@@ -281,7 +281,7 @@ Fire this event when one or more items are purchased by a user.
 **Example**
 
 ```javascript
-cact('trigger', purchase, {
+cact('trigger', 'purchase', {
   "payment_method": "card",
   "status": "in_progress",
   "revenue": 16,
@@ -363,7 +363,7 @@ Fire this event when a purchase was refund.
 **Example**
 
 ```javascript
-cact('trigger', refund, {
+cact('trigger', 'refund', {
   "revenue": 16,
   "shipping_amount": 3.33,
   "tax_amount": 3.2,
@@ -438,7 +438,7 @@ This event signifies that an item was removed from a cart.
 **Example**
 
 ```javascript
-cact('trigger', remove_from_cart, {
+cact('trigger', 'remove_from_cart', {
   "value": 8,
   "currency": "EUR",
   "items": [
@@ -470,7 +470,7 @@ Use this event to contextualize search operations. This event can help you ident
 **Example**
 
 ```javascript
-cact('trigger', search, {
+cact('trigger', 'search', {
   "search_term": "t-shirt",
   "user": {
     "id": "84545"
@@ -495,7 +495,7 @@ This event signifies that a user has selected some content of a certain type. Th
 **Example**
 
 ```javascript
-cact('trigger', select_content, {
+cact('trigger', 'select_content', {
   "content_type": "product",
   "item_id": "I_12345",
   "user": {
@@ -520,7 +520,7 @@ This event signifies an item was selected from a list.
 **Example**
 
 ```javascript
-cact('trigger', select_item, {
+cact('trigger', 'select_item', {
   "items": [
     {
       "product": {
@@ -550,7 +550,7 @@ This event indicates that a user has signed up for an account.
 **Example**
 
 ```javascript
-cact('trigger', sign_up, {
+cact('trigger', 'sign_up', {
   "method": "email",
   "user": {
     "id": "84545"
@@ -576,7 +576,7 @@ This event signifies that a user viewed their cart.
 **Example**
 
 ```javascript
-cact('trigger', view_cart, {
+cact('trigger', 'view_cart', {
   "value": 8,
   "currency": "EUR",
   "items": [
@@ -610,7 +610,7 @@ This event signifies that some content was shown to the user. Use this event to 
 **Example**
 
 ```javascript
-cact('trigger', view_item, {
+cact('trigger', 'view_item', {
   "revenue": 16,
   "currency": "EUR",
   "items": [
@@ -642,7 +642,71 @@ Log this event when the user has been presented with a list of items of a certai
 **Example**
 
 ```javascript
-cact('trigger', view_item_list, {
+cact('trigger', 'view_item_list', {
+  "items": [
+    {
+      "product": {
+        "id": 1234
+      }
+    }
+  ],
+  "user": {
+    "id": "84545"
+  }
+})
+```
+
+
+
+
+## Custom Event <a href="#Custom Event" id="Custom Event"></a>
+
+Un event custom, généré à partir des autres règles déjà existantes. <br>Les cellules vides dans le tableau et les `<undefined>` dans l'exemple montrent des points restant à spécifier.<br><br>**Exemples :**
+
+* Comment décrit-on `status` pour le cas général ?
+* `item_id` ne pourrait-il pas être migré vers items ?
+* Comment peut-on ajouter des champs *classiques* (pas besoin de les recommander pour les events, mais on sait que ça peut arriver)
+* Arrive-t-on bien à faire la distinction entre les différents champs (ex: `type`, `content_type`, `items`)
+
+
+
+**Parameters (required and recommended)**
+
+| Name | Type | Required | Example | Description |
+| ---- | ---- | -------- | ------- | ----------- |
+| `payment_method` | `string` | No | card | The chosen method of payment (see list of possible values below) |
+| `status` | `string` | No |  |  |
+| `revenue` | `number` | No | 16.00 | Revenue (shipping price and taxes **excluded**) after discount. |
+| `shipping_amount` | `number` | No | 3.33 | Shipping cost associated with a transaction. |
+| `tax_amount` | `number` | No | 3.20 | Tax cost associated with a transaction. |
+| `value` | `number` | No |  | The monetary value of the event |
+| `currency` | `string` (ISO 4217) | No | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
+| `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
+| `type` | `string` | No |  |  |
+| `content_type` | `string` | No |  |  |
+| `search_term` | `string` | No |  |  |
+| `item_id` | `string` | No |  |  |
+| `method` | `string` | No |  |  |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+
+**Example**
+
+```javascript
+cact('trigger', 'my_custom_event', {
+  "payment_method": "card",
+  "status": "<undefined>",
+  "revenue": 16,
+  "shipping_amount": 3.33,
+  "tax_amount": 3.2,
+  "value": "<undefined>",
+  "currency": "EUR",
+  "coupon": "CHRISTMAS",
+  "type": "<undefined>",
+  "content_type": "<undefined>",
+  "search_term": "<undefined>",
+  "item_id": "<undefined>",
+  "method": "<undefined>",
   "items": [
     {
       "product": {
@@ -661,7 +725,12 @@ cact('trigger', view_item_list, {
 
 ## - COMMON SCHEMAS -
 
-...todo user/item/product...
+...todo user/item/product/integrations...
+
+
+## - AUTO FIELDS -
+
+...todo page/device...
 
 ## - ENUMERATED VALUE -
 

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -11,9 +11,9 @@ This event signifies a user has submitted their payment information
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `payment_method` | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
-| `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
+| `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
@@ -23,9 +23,9 @@ This event signifies a user has submitted their payment information
 ```javascript
 cact('trigger', add_payment_info, {
   "payment_method": "card",
-  "value": 22.53,
-  "currency": "EUR",
   "revenue": 16,
+  "currency": "EUR",
+  "value": 22.53,
   "coupon": "CHRISTMAS",
   "items": [
     {
@@ -154,9 +154,9 @@ This event signifies that a user has begun a checkout.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
-| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
+| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
@@ -165,9 +165,9 @@ This event signifies that a user has begun a checkout.
 
 ```javascript
 cact('trigger', begin_checkout, {
-  "value": 22.53,
-  "currency": "EUR",
   "revenue": 16,
+  "currency": "EUR",
+  "value": 22.53,
   "coupon": "CHRISTMAS",
   "items": [
     {
@@ -268,11 +268,11 @@ Fire this event when one or more items are purchased by a user.
 | ---- | ---- | -------- | ------- | ----------- |
 | `payment_method` | `string` | Yes | card | Payment method type (see list of possible values below) |
 | `status` | `string` | Yes | in_progress | Status of the conversion (see list of  below). <br>Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
-| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
-| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `revenue` | `number` | Yes | 16.00 | Revenue (shipping price and taxes **excluded**) after discount. |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `shipping_amount` | `number` | No | 3.33 | Shipping cost associated with a transaction. |
 | `tax_amount` | `number` | No | 3.20 | Tax cost associated with a transaction. |
+| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
@@ -284,11 +284,11 @@ Fire this event when one or more items are purchased by a user.
 cact('trigger', purchase, {
   "payment_method": "card",
   "status": "in_progress",
-  "value": 22.53,
-  "currency": "EUR",
   "revenue": 16,
+  "currency": "EUR",
   "shipping_amount": 3.33,
   "tax_amount": 3.2,
+  "value": 22.53,
   "coupon": "CHRISTMAS",
   "type": "offline",
   "items": [
@@ -350,11 +350,11 @@ Fire this event when a purchase was refund.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
-| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `revenue` | `number` | Yes | 16.00 | Revenue (shipping price and taxes **excluded**) after discount. |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `shipping_amount` | `number` | No | 3.33 | Shipping cost associated with a transaction. |
 | `tax_amount` | `number` | No | 3.20 | Tax cost associated with a transaction. |
+| `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | `items` is required for partial refunds, but it can be omitted for full refunds. |
@@ -364,11 +364,11 @@ Fire this event when a purchase was refund.
 
 ```javascript
 cact('trigger', refund, {
-  "value": 22.53,
-  "currency": "EUR",
   "revenue": 16,
+  "currency": "EUR",
   "shipping_amount": 3.33,
   "tax_amount": 3.2,
+  "value": 22.53,
   "coupon": "CHRISTMAS",
   "type": "offline",
   "items": [

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -1,5 +1,19 @@
 # Events Reference
 
+This will be rephrased :
+
+* When an event occurs, `properties` object is a free data "space" were anyone can place any kind of information
+* When you want to set a property, here is how to think :
+  * first, anything is accepted
+  * but, to make things clean and easier to process, some properties are already specified (optional, but with specific type and purpose)
+  * then, for standard events, some of those properties become more specific
+    * expects something very accurate (e.g.: pricing with `value`, `revenue` should be numbers, and will be used for calculations and will be sent to many destinations under derived formats)
+    * parameters can become mandatory (and events will be rejected or will raise warnings)
+* Override content for specific destinations using `integrations`
+* Automatic data are set at the upper-level (not in `properties` but in `page` and `device`)
+  * e.g.: you don't have to put the page location (window.location), page language (document.lang) or the device language (nav.language) inside your properties because it already is sent automatically
+
+
 
 ## add\_payment\_info <a href="#add_payment_info" id="add_payment_info"></a>
 

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -1,5 +1,4 @@
-# Events reference
-
+# Events Reference
 
 
 ## add\_payment\_info <a href="#add_payment_info" id="add_payment_info"></a>
@@ -658,16 +657,16 @@ cact('trigger', 'view_item_list', {
 
 
 
-
 ## Custom Event <a href="#Custom Event" id="Custom Event"></a>
 
-Un event custom, généré à partir des autres règles déjà existantes. <br>Les cellules vides dans le tableau et les `<undefined>` dans l'exemple montrent des points restant à spécifier.<br><br>**Exemples :**
+Un event custom, généré à partir des autres règles déjà existantes.<br>Les cellules vides dans le tableau et les `<undefined>` dans l'exemple montrent des points restant à spécifier.
+
+**Exemples :**
 
 * Comment décrit-on `status` pour le cas général ?
 * `item_id` ne pourrait-il pas être migré vers items ?
 * Comment peut-on ajouter des champs *classiques* (pas besoin de les recommander pour les events, mais on sait que ça peut arriver)
 * Arrive-t-on bien à faire la distinction entre les différents champs (ex: `type`, `content_type`, `items`)
-
 
 
 **Parameters (required and recommended)**
@@ -719,8 +718,6 @@ cact('trigger', 'my_custom_event', {
   }
 })
 ```
-
-
 
 
 ## - COMMON SCHEMAS -

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -15,8 +15,8 @@ This event signifies a user has submitted their payment information
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -53,8 +53,8 @@ This event signifies a user has submitted their shipping information.
 | `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -88,8 +88,8 @@ This event signifies that an item was added to a cart for purchase.
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | Yes | 8.00 | The monetary value of the event |
 | `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -122,8 +122,8 @@ The event signifies that an item was added to a wishlist. Use this event to iden
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -158,8 +158,8 @@ This event signifies that a user has begun a checkout.
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -194,7 +194,7 @@ Log this event when a lead has been generated to understand the efficacy of your
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -219,7 +219,7 @@ Send this event to signify that a user has logged in.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `method` | `string` | No | LinkedIn | The method used to login. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -243,7 +243,7 @@ The `page_view` call lets you record whenever a user sees a page of your website
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `type` | `string` | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -275,8 +275,8 @@ Fire this event when one or more items are purchased by a user.
 | `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -357,8 +357,8 @@ Fire this event when a purchase was refund.
 | `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | `items` is required for partial refunds, but it can be omitted for full refunds. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No |   | `items` is required for partial refunds, but it can be omitted for full refunds. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -432,8 +432,8 @@ This event signifies that an item was removed from a cart.
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -465,7 +465,7 @@ Use this event to contextualize search operations. This event can help you ident
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `search_term` | `string` | Yes | t-shirt | The term that was searched for. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -490,7 +490,7 @@ This event signifies that a user has selected some content of a certain type. Th
 | ---- | ---- | -------- | ------- | ----------- |
 | `content_type` | `string` | No | product | The type of selected content. |
 | `item_id` | `string` | No | I_12345 | An identifier for the item that was selected. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -514,8 +514,8 @@ This event signifies an item was selected from a list.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -545,7 +545,7 @@ This event indicates that a user has signed up for an account.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `method` | `string` | No | email | The method used for sign up. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -570,8 +570,8 @@ This event signifies that a user viewed their cart.
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `number` | No* | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -604,8 +604,8 @@ This event signifies that some content was shown to the user. Use this event to 
 | ---- | ---- | -------- | ------- | ----------- |
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 
@@ -636,8 +636,8 @@ Log this event when the user has been presented with a list of items of a certai
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
 
 **Example**
 

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -9,8 +9,8 @@ This event signifies a user has submitted their payment information
 | `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -43,8 +43,8 @@ This event signifies a user has submitted their shipping information.
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -74,8 +74,8 @@ This event signifies that an item was added to a cart for purchase.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `string` | Yes | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -104,8 +104,8 @@ The event signifies that an item was added to a wishlist. Use this event to iden
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -136,8 +136,8 @@ This event signifies that a user has begun a checkout.
 | `value` | `string` | Yes | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -168,7 +168,7 @@ Log this event when a lead has been generated to understand the efficacy of your
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -189,7 +189,7 @@ Send this event to signify that a user has logged in.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 | `method` | `string` | No | LinkedIn | The method used to login. |
 
 **Parameters (required and recommended)**
@@ -212,7 +212,7 @@ The `page_view` call lets you record whenever a user sees a page of your website
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `type` | `string` | Yes | product_list | Page category. Equivalent to `tc_vars.env_template` |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -241,8 +241,8 @@ Fire this event when one or more items are purchased by a user.
 | `tax_amount` | `string` | No | 3.33 | Tax cost associated with a transaction. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -283,8 +283,8 @@ Fire this event when a purchase was refund.
 | `tax_amount` | `string` | No | 3.33 | Tax cost associated with a transaction. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | `items` is required for partial refunds, but it can be omitted for full refunds. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | `items` is required for partial refunds, but it can be omitted for full refunds. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -318,8 +318,8 @@ This event signifies that an item was removed from a cart.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -348,7 +348,7 @@ Use this event to contextualize search operations. This event can help you ident
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `search_term` | `string` | Yes | t-shirt | The term that was searched for. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -371,7 +371,7 @@ This event signifies that a user has selected some content of a certain type. Th
 | ---- | ---- | -------- | ------- | ----------- |
 | `content_type` | `string` | No | product | The type of selected content. |
 | `item_id` | `string` | No | I_12345 | An identifier for the item that was selected. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -393,8 +393,8 @@ This event signifies an item was selected from a list.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -421,7 +421,7 @@ This event indicates that a user has signed up for an account.
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 | `method` | `string` | No | email | The method used for sign up. |
 
 **Parameters (required and recommended)**
@@ -444,8 +444,8 @@ This event signifies that a user viewed their cart.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `value` | `string` | No | 8.00 | The monetary value of the event<br>(*) `value` is typically required for meaningful reporting |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -474,8 +474,8 @@ This event signifies that some content was shown to the user. Use this event to 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -503,8 +503,8 @@ Log this event when the user has been presented with a list of items of a certai
 
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 
@@ -535,8 +535,8 @@ This event signifies a user has submitted their payment information
 | `value` | `string` | No | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
 | `revenue` | `string` | No | 16.00 | Revenue (shipping price and taxes excluded) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
-| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | [{"product":{"id":1234}}] | The items for the event. |
-| `user` | <a href="#user">`Object<User>`</a> | Yes | {"id":"84545"} | The items for the event. |
+| `items` | <a href="#item">`Array<Object<Item>>`</a> | No | `[{"product":{"id":1234}}]` | The items for the event. |
+| `user` | <a href="#user">`Object<User>`</a> | Yes | `{"id":"84545"}` | The items for the event. |
 
 **Parameters (required and recommended)**
 

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -12,8 +12,8 @@ This event signifies a user has submitted their payment information
 | ---- | ---- | -------- | ------- | ----------- |
 | `payment_method` | `string` | Yes | card | The chosen method of payment (see list of possible values below) |
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `value` | `number` | No* | 22.53 | The monetary value of the event (shipping price and taxes included) after discount<br>(*) `value` is typically required for meaningful reporting |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No |   | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
@@ -24,8 +24,8 @@ This event signifies a user has submitted their payment information
 cact('trigger', add_payment_info, {
   "payment_method": "card",
   "revenue": 16,
-  "currency": "EUR",
   "value": 22.53,
+  "currency": "EUR",
   "coupon": "CHRISTMAS",
   "items": [
     {
@@ -155,8 +155,8 @@ This event signifies that a user has begun a checkout.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `revenue` | `number` | No* | 16.00 | Revenue (shipping price and taxes **excluded**) after discount.<br>(*) `revenue` is typically required for meaningful reporting |
-| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
+| `currency` | `string` (ISO 4217) | No* | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format.<br>(*) If you supply a pricing parameter (e.g. `value`, `revenue`), the currency becomes mandatory. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
 | `user` | <a href="#user">`Object<User>`</a> | Yes |   | Object containing user identity (`id`, `email`, ...) and consents (`consent_categories`). |
@@ -166,8 +166,8 @@ This event signifies that a user has begun a checkout.
 ```javascript
 cact('trigger', begin_checkout, {
   "revenue": 16,
-  "currency": "EUR",
   "value": 22.53,
+  "currency": "EUR",
   "coupon": "CHRISTMAS",
   "items": [
     {
@@ -269,10 +269,10 @@ Fire this event when one or more items are purchased by a user.
 | `payment_method` | `string` | Yes | card | Payment method type (see list of possible values below) |
 | `status` | `string` | Yes | in_progress | Status of the conversion (see list of  below). <br>Conversions with status "pending" are not included in default sum and counts aggregated on augmented user attributes feature |
 | `revenue` | `number` | Yes | 16.00 | Revenue (shipping price and taxes **excluded**) after discount. |
-| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `shipping_amount` | `number` | No | 3.33 | Shipping cost associated with a transaction. |
 | `tax_amount` | `number` | No | 3.20 | Tax cost associated with a transaction. |
 | `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | Yes |   | The items for the event. |
@@ -285,10 +285,10 @@ cact('trigger', purchase, {
   "payment_method": "card",
   "status": "in_progress",
   "revenue": 16,
-  "currency": "EUR",
   "shipping_amount": 3.33,
   "tax_amount": 3.2,
   "value": 22.53,
+  "currency": "EUR",
   "coupon": "CHRISTMAS",
   "type": "offline",
   "items": [
@@ -351,10 +351,10 @@ Fire this event when a purchase was refund.
 | Name | Type | Required | Example | Description |
 | ---- | ---- | -------- | ------- | ----------- |
 | `revenue` | `number` | Yes | 16.00 | Revenue (shipping price and taxes **excluded**) after discount. |
-| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `shipping_amount` | `number` | No | 3.33 | Shipping cost associated with a transaction. |
 | `tax_amount` | `number` | No | 3.20 | Tax cost associated with a transaction. |
 | `value` | `number` | Yes | 22.53 | The monetary value of the event (shipping price and taxes **included**) after discount |
+| `currency` | `string` (ISO 4217) | Yes | EUR | Currency of the purchase or items associated with the event, in 3-letter ISO 4217 format. |
 | `coupon` | `string` | No | CHRISTMAS | Coupon code used for a purchase. |
 | `type` | `string` | Yes | offline | Type of conversion (online, offline, call etc.) |
 | `items` | <a href="#item">`Array<Object<Item>>`</a> | No |   | `items` is required for partial refunds, but it can be omitted for full refunds. |
@@ -365,10 +365,10 @@ Fire this event when a purchase was refund.
 ```javascript
 cact('trigger', refund, {
   "revenue": 16,
-  "currency": "EUR",
   "shipping_amount": 3.33,
   "tax_amount": 3.2,
   "value": 22.53,
+  "currency": "EUR",
   "coupon": "CHRISTMAS",
   "type": "offline",
   "items": [

--- a/developers/tracking/events-reference-auto.md
+++ b/developers/tracking/events-reference-auto.md
@@ -1,3 +1,6 @@
+# Events reference
+
+
 
 ## add\_payment\_info <a href="#add_payment_info" id="add_payment_info"></a>
 
@@ -290,8 +293,44 @@ cact('trigger', purchase, {
   "type": "offline",
   "items": [
     {
+      "id": "SKU_12345",
+      "quantity": 1,
+      "price": 9.99,
+      "variant": "red",
+      "coupon": "CHRISTMAS",
+      "discount": 1.99,
       "product": {
-        "id": 1234
+        "id": "12345",
+        "name": "Trex tshirt",
+        "category_1": "clothes",
+        "category_2": "t-shirts",
+        "category_3": "boy",
+        "brand": "Lacoste",
+        "colors": [
+          "red"
+        ],
+        "price": 9.99
+      }
+    },
+    {
+      "id": "SKU_12346",
+      "quantity": 1,
+      "price": 9.99,
+      "variant": "green",
+      "coupon": "CHRISTMAS",
+      "discount": 1.99,
+      "product": {
+        "id": "12346",
+        "name": "Heart tshirt",
+        "category_1": "clothes",
+        "category_2": "t-shirts",
+        "category_3": "girl",
+        "brand": "Jenyfion",
+        "colors": [
+          "blue",
+          "white"
+        ],
+        "price": 9.99
       }
     }
   ],
@@ -334,8 +373,44 @@ cact('trigger', refund, {
   "type": "offline",
   "items": [
     {
+      "id": "SKU_12345",
+      "quantity": 1,
+      "price": 9.99,
+      "variant": "red",
+      "coupon": "CHRISTMAS",
+      "discount": 1.99,
       "product": {
-        "id": 1234
+        "id": "12345",
+        "name": "Trex tshirt",
+        "category_1": "clothes",
+        "category_2": "t-shirts",
+        "category_3": "boy",
+        "brand": "Lacoste",
+        "colors": [
+          "red"
+        ],
+        "price": 9.99
+      }
+    },
+    {
+      "id": "SKU_12346",
+      "quantity": 1,
+      "price": 9.99,
+      "variant": "green",
+      "coupon": "CHRISTMAS",
+      "discount": 1.99,
+      "product": {
+        "id": "12346",
+        "name": "Heart tshirt",
+        "category_1": "clothes",
+        "category_2": "t-shirts",
+        "category_3": "girl",
+        "brand": "Jenyfion",
+        "colors": [
+          "blue",
+          "white"
+        ],
+        "price": 9.99
       }
     }
   ],
@@ -580,5 +655,25 @@ cact('trigger', view_item_list, {
   }
 })
 ```
+
+
+
+
+## - COMMON SCHEMAS -
+
+...todo user/item/product...
+
+## - ENUMERATED VALUE -
+
+...todo payment_method/purchase#status...
+
+## Pricing rules
+
+1. currency required when any pricing information specified
+2. calculation value = fn(revenue, ship, tax, discount)
+
+Examples:
+
+...
 
 


### PR DESCRIPTION
This pull request is in progress.

Aim is to see how a generated **Events Reference** can be used in our documentation

* **Generated version :** [here](https://github.com/TagCommander/Platform-Documentation/blob/evol/adub/auto-reference-generator-CDPBC-170/developers/tracking/events-reference-auto.md)
* **Original version :** [here](https://github.com/TagCommander/Platform-Documentation/blob/master/developers/tracking/events-reference.md)