### PR TITLE
Specify appropriate ip & user_agent paths

### DIFF
--- a/features/destinations/destinations-catalog/facebook/facebook-conversions-api.md
+++ b/features/destinations/destinations-catalog/facebook/facebook-conversions-api.md
@@ -168,8 +168,8 @@ If you want to change the name of the custom event that will receive Facebook, y
 | `user.state`                                                                                                                       | `user_data.st` (state, hashed)      |
 | `user.zipcode`                                                                                                                     | `user_data.zp` (zip code, hashed)   |
 | `user.country`                                                                                                                     | `user_data.country` (hashed)        |
-| <p><code>browser.ip</code><br><em>Automatically set if generated from Commanders Act OneTag</em></p>                               | `user_data.client_ip_address`       |
-| <p><code>browser.user_agent</code><br><em>Automatically set if generated from Commanders Act OneTag</em></p>                       | `user_data.client_user_agent`       |
+| <p><code>context.device.ip</code><br><em>Automatically set if generated from Commanders Act OneTag</em></p>                        | `user_data.client_ip_address`       |
+| <p><code>context.device.user_agent</code><br><em>Automatically set if generated from Commanders Act OneTag</em></p>                | `user_data.client_user_agent`       |
 | <p><code>The cookie "fbc"</code></p><p><em>Automatically created by the Facebook Pixel client-side tag.</em></p>                   | `user_data.fbc` (Click ID)          |
 | <p><code>The cookie "fbp"</code></p><p><em>Automatically created by the Facebook Pixel client-side tag.</em></p>                   | `user_data.fbp` (Browser ID)        |
 | `value`                                                                                                                            | `custom_data.value`                 |


### PR DESCRIPTION
## Context 

The specified path is wrong for the properties mapped from our CommandersAct events to Facebook properties : `user_data.client_ip_address` and `user_data.client_user_agent`

## Changes

Using appropriate paths

* `browser.ip` -> `context.device.ip`
* `browser.user_agent` -> `context.device.user_agent`